### PR TITLE
Helpful msg for debugging.

### DIFF
--- a/src/rotel/__init__.py
+++ b/src/rotel/__init__.py
@@ -19,6 +19,8 @@ def _client_with_config() -> Rotel:
         except KeyError as error:
             raise InvalidConfigError("The __rotel__.py file is invalid")
     # Use defaults
+    if os.environ.get("ROTEL_IGNORE_CONFIG_FILE_CHECK") is None:
+        print(f"Rotel could not locate the __rotel__.py config file, using defaults.")
     return Rotel()
 
 def _must_initialize_client() -> Rotel:


### PR DESCRIPTION
Add a message if we can't locate the `__rotel__.py` configuration file when we're trying to initialize rotel. It's unclear if user's will find this approach useful over just setting a bunch of environment variables, but it seems to be a somewhat common pattern. We can always remove this if it becomes annoying.

Completes: STR-3124