### PR TITLE
Add src import check to lint CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,28 @@ jobs:
 
       - name: Run lint
         run: hatch run lint:check
+
+      - name: Check for invalid src imports
+        shell: bash
+        run: |
+          PATTERN="^from src\..*import.*"
+
+          # Find files matching the pattern, excluding .git directory
+          # Using -E for extended regular expressions instead of -P for perl regex
+          # -l flag makes grep only output filenames that match
+          MATCHES=$(grep -r -l -E "$PATTERN" --exclude-dir=".git" src || true)
+
+          if [ -n "$MATCHES" ]; then
+            echo "::error::Found prohibited pattern matches in the following files:"
+            echo "$MATCHES" | while read file; do
+              echo "::error::$file"
+              # Show the actual matches with line numbers, also using -E
+              grep -n -E "$PATTERN" "$file" | while read match; do
+                echo "::error::  $match"
+              done
+            done
+            exit 1  # Fail the GitHub action
+          else
+            echo "Success: No prohibited pattern matches found!"
+            exit 0  # Action succeeds
+          fi

--- a/src/rotel/config.py
+++ b/src/rotel/config.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import os
 from typing import TypedDict, cast
 
-#from .error import _errlog
-from src.rotel.error import _errlog
+from .error import _errlog
 
 
 class OTLPExporterEndpoint(TypedDict, total=False):

--- a/src/rotel/config.py
+++ b/src/rotel/config.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import os
 from typing import TypedDict, cast
 
-from .error import _errlog
+#from .error import _errlog
+from src.rotel.error import _errlog
 
 
 class OTLPExporterEndpoint(TypedDict, total=False):


### PR DESCRIPTION
JB tools seem to auto complete imports with `src.` and we don't fail them on CI. Quick hack to catch them early on.

Completes: STR-3163