### PR TITLE
Support the Datadog exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Python package for the Rotel lightweight OpenTelemetry collector.
 
 ## Description
 
-This package provides an embedded OpenTelemetry collector, built on the lightweight Rotel collector. When started, it spawns a background daemon that accepts OpenTelemetry metrics, traces, and logs. Designed for minimal overhead, Rotel reduces resource consumption while simplifying telemetry collection and processing in complex Python applications—without requiring additional sidecar containers.
+This package provides an embedded OpenTelemetry collector, built on the lightweight [Rotel collector](https://github.com/streamfold/rotel). When started, it spawns a background daemon that accepts OpenTelemetry metrics, traces, and logs. Designed for minimal overhead, Rotel reduces resource consumption while simplifying telemetry collection and processing in complex Python applications—without requiring additional sidecar containers.
 
 | Telemetry Type | Support |
 |----------------|---------|

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Add the `rotel` Python package to your project's dependencies. There are two app
 In the startup section of your `main.py` add the following code block. Replace the endpoint with the endpoint of your OpenTelemetry vendor and any required API KEY headers. 
 
 ```python
-from rotel import OTLPExporter, Rotel
+from rotel import Config, Rotel
 
 rotel = Rotel(
     enabled = True,
-    exporter = OTLPExporter(
+    exporter = Config.otlp_exporter(
         endpoint = "https://foo.example.com",
         headers = {
             "x-api-key" : settings.API_KEY,
@@ -81,21 +81,21 @@ To set the endpoint the OpenTelemetry SDK will use, set the following environmen
 
 This is the full list of options and their environment variable alternatives. Any defaults left blank in the table are either False or None.
 
-| Option Name                    | Type         | Environ                              | Default              | Options               |
-|--------------------------------|--------------|--------------------------------------|----------------------|-----------------------|
-| enabled                        | bool         | ROTEL_ENABLED                        |                      |                       |
-| pid_file                       | str          | ROTEL_PID_FILE                       | /tmp/rotel-agent.pid |                       |
-| log_file                       | str          | ROTEL_LOG_FILE                       | /tmp/rotel-agent.log |                       |
-| log_format                     | str          | ROTEL_LOG_FORMAT                     | text                 | json, text            |
-| debug_log                      | list[str]    | ROTEL_DEBUG_LOG                      |                      | traces, metrics, logs |
-| otlp_grpc_endpoint             | str          | ROTEL_OTLP_GRPC_ENDPOINT             | localhost:4317       |                       |
-| otlp_http_endpoint             | str          | ROTEL_OTLP_HTTP_ENDPOINT             | localhost:4318       |                       |
-| otlp_receiver_traces_disabled  | bool         | ROTEL_OTLP_RECEIVER_TRACES_DISABLED  |                      |                       |
-| otlp_receiver_metrics_disabled | bool         | ROTEL_OTLP_RECEIVER_METRICS_DISABLED |                      |                       |
-| otlp_receiver_logs_disabled    | bool         | ROTEL_OTLP_RECEIVER_LOGS_DISABLED    |                      |                       |
-| exporter                       | OTLPExporter |                                      |                      |                       |
+| Option Name                    | Type                            | Environ                              | Default              | Options               |
+|--------------------------------|---------------------------------|--------------------------------------|----------------------|-----------------------|
+| enabled                        | bool                            | ROTEL_ENABLED                        |                      |                       |
+| pid_file                       | str                             | ROTEL_PID_FILE                       | /tmp/rotel-agent.pid |                       |
+| log_file                       | str                             | ROTEL_LOG_FILE                       | /tmp/rotel-agent.log |                       |
+| log_format                     | str                             | ROTEL_LOG_FORMAT                     | text                 | json, text            |
+| debug_log                      | list[str]                       | ROTEL_DEBUG_LOG                      |                      | traces, metrics, logs |
+| otlp_grpc_endpoint             | str                             | ROTEL_OTLP_GRPC_ENDPOINT             | localhost:4317       |                       |
+| otlp_http_endpoint             | str                             | ROTEL_OTLP_HTTP_ENDPOINT             | localhost:4318       |                       |
+| otlp_receiver_traces_disabled  | bool                            | ROTEL_OTLP_RECEIVER_TRACES_DISABLED  |                      |                       |
+| otlp_receiver_metrics_disabled | bool                            | ROTEL_OTLP_RECEIVER_METRICS_DISABLED |                      |                       |
+| otlp_receiver_logs_disabled    | bool                            | ROTEL_OTLP_RECEIVER_LOGS_DISABLED    |                      |                       |
+| exporter                       | OTLPExporter \| DatadogExporter |                                      | otlp                 | otlp, datadog         |
 
-The OTLPExporter can be enabled with the following options.
+To construct an OTLP exporter, use the method `Config.otlp_exporter()` with the following options.
 
 | Option Name            | Type           | Environ                                    | Default | Options      |
 |------------------------|----------------|--------------------------------------------|---------|--------------|
@@ -114,17 +114,30 @@ The OTLPExporter can be enabled with the following options.
 | tls_ca_file            | str            | ROTEL_OTLP_EXPORTER_TLS_CA_FILE            |         |              |
 | tls_skip_verify        | bool           | ROTEL_OTLP_EXPORTER_TLS_SKIP_VERIFY        |         |              |
 
+Rotel provides an experimental [Datadog exporter](https://github.com/streamfold/rotel/blob/main/src/exporters/datadog/README.md)
+that supports traces at the moment. To use it instead of the OTLP exporter,
+use the method `Config.datadog_exporter()` with the following options.
+
+| Option Name     | Type | Environ                                | Default | Options                |
+|-----------------|------|----------------------------------------|---------|------------------------|
+| region          | str  | ROTEL_DATADOG_EXPORTER_REGION          | us1     | us1, us3, us5, eu, ap1 |
+| custom_endpoint | str  | ROTEL_DATADOG_EXPORTER_CUSTOM_ENDPOINT |         |                        |
+| api_key         | str  | ROTEL_DATADOG_EXPORTER_API_KEY         |         |                        |
+
+When configuring Rotel with only environment variables, you must set `ROTEL_EXPORTER=datadog` in addition to the above
+environment variables.
+
 ### Endpoint overrides
 
 When using the OTLP exporter over HTTP, the exporter will append `/v1/traces`, `/v1/metrics`, or `/v1/logs` to the endpoint URL for traces, metrics, and logs respectively. If the service you are exporting telemetry data to does not support these standard URL paths, you can individually override them for traces, metrics, and logs.
 
 For example, to override the endpoint for traces and metrics you can do the following:
 ```python
-from rotel import OTLPExporter, OTLPExporterEndpoint, Rotel
+from rotel import Config, OTLPExporterEndpoint, Rotel
 
 rotel = Rotel(
     enabled = True,
-    exporter = OTLPExporter(
+    exporter = Config.otlp_exporter(
         headers = {
             "x-api-key": settings.API_KEY,
         },
@@ -174,7 +187,7 @@ The code sample depends on the following environment variables:
 ```python
 import os
 
-from rotel import Rotel, OTLPExporter
+from rotel import Config, Rotel
 
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
@@ -188,7 +201,7 @@ if os.environ.get("ROTEL_ENABLED") == "true":
     #
     # Configure Rotel to export to Axiom
     #
-    otlp_exporter = OTLPExporter(
+    otlp_exporter = Config.otlp_exporter(
         endpoint="https://api.axiom.co",
         protocol="http", # Axiom only supports HTTP
         headers={
@@ -234,6 +247,22 @@ if os.environ.get("ROTEL_ENABLED") == "true":
 ```
 
 For the complete example, see the [hello world](https://github.com/streamfold/pyrotel-hello-world) application.
+
+### Datadog exporter example
+
+To use the Datadog trace exporter instead, configure and start rotel as such:
+```python
+from rotel import Config, Rotel
+
+rotel = Rotel(
+    enabled = True,
+    exporter = Config.datadog_exporter(
+        region = "us1",
+        api_key = "1bde13d9cb1675c5ca8188c8c86066c9",
+    ),
+)
+rotel.start()
+```
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This is the full list of options and their environment variable alternatives. An
 | otlp_receiver_traces_disabled  | bool                            | ROTEL_OTLP_RECEIVER_TRACES_DISABLED  |                      |                       |
 | otlp_receiver_metrics_disabled | bool                            | ROTEL_OTLP_RECEIVER_METRICS_DISABLED |                      |                       |
 | otlp_receiver_logs_disabled    | bool                            | ROTEL_OTLP_RECEIVER_LOGS_DISABLED    |                      |                       |
-| exporter                       | OTLPExporter \| DatadogExporter |                                      | otlp                 | otlp, datadog         |
+| exporter                       | OTLPExporter \| DatadogExporter |                                      |                      |                       |
 
 To construct an OTLP exporter, use the method `Config.otlp_exporter()` with the following options.
 

--- a/scripts/build_hook.py
+++ b/scripts/build_hook.py
@@ -19,7 +19,7 @@ def run_relative(filename: str) -> dict[str, Any]:
 PLATFORM_TAGS = run_relative("platform.py")["PLATFORM_TAGS"]
 PLATFORM_FILE_ARCH = run_relative("platform.py")["PLATFORM_FILE_ARCH"]
 
-ROTEL_RELEASE="v0.0.1-alpha0"
+ROTEL_RELEASE="v0.0.1-alpha1"
 
 def current_platform_arch():
     platform = sysconfig.get_platform()

--- a/src/rotel/config.py
+++ b/src/rotel/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from typing import TypedDict, cast
 
+
 try:
     from typing import Unpack
 except ImportError:

--- a/src/rotel/config.py
+++ b/src/rotel/config.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import os
 from typing import TypedDict, cast
 
+try:
+    from typing import Unpack
+except ImportError:
+    from typing_extensions import Unpack
+
 from .error import _errlog
 
 
@@ -26,6 +31,7 @@ class OTLPExporterEndpoint(TypedDict, total=False):
 
 # TODO: when we have more, include a key that defines this exporter type
 class OTLPExporter(TypedDict, total=False):
+    _type: str | None
     endpoint: str | None
     protocol: str | None
     headers: dict[str, str] | None
@@ -45,6 +51,12 @@ class OTLPExporter(TypedDict, total=False):
     metrics: OTLPExporterEndpoint | None
     logs: OTLPExporterEndpoint | None
 
+class DatadogExporter(TypedDict, total=False):
+    _type: str | None # set with builder method
+    region: str | None
+    custom_endpoint: str | None
+    api_key: str | None
+
 class Options(TypedDict, total=False):
     enabled: bool | None
     pid_file: str | None
@@ -56,8 +68,7 @@ class Options(TypedDict, total=False):
     otlp_receiver_traces_disabled: bool | None
     otlp_receiver_metrics_disabled: bool | None
     otlp_receiver_logs_disabled: bool | None
-    exporter: OTLPExporter | None
-
+    exporter: OTLPExporter | DatadogExporter | None
 
 class Config:
     DEFAULT_OPTIONS = Options(
@@ -80,6 +91,18 @@ class Config:
 
     def is_active(self) -> bool:
         return self.options["enabled"] and self.valid
+
+    @staticmethod
+    def datadog_exporter(**options: Unpack[DatadogExporter]) -> DatadogExporter:
+        """Construct a Datadog exporter config"""
+        options["_type"] = "datadog"
+        return options
+
+    @staticmethod
+    def otlp_exporter(**options: Unpack[OTLPExporter]) -> OTLPExporter:
+        """Construct an OTLP exporter config"""
+        options["_type"] = "otlp"
+        return options
 
     @staticmethod
     def _load_options_from_env() -> Options:
@@ -113,6 +136,15 @@ class Config:
             endpoint = Config._load_otlp_exporter_options_from_env("LOGS", OTLPExporterEndpoint)
             if endpoint is not None:
                 exporter["logs"] = endpoint
+        if exporter_type == "datadog":
+            pfx = "DATADOG_EXPORTER_"
+            exporter = DatadogExporter(
+                _type = "datadog",
+                region = rotel_env(pfx + "REGION"),
+                custom_endpoint = rotel_env(pfx + "CUSTOM_ENDPOINT"),
+                api_key = rotel_env(pfx + "API_KEY"),
+            )
+            env["exporter"] = exporter
 
         final_env = Options()
 
@@ -148,7 +180,6 @@ class Config:
                 return endpoint
         return None
 
-
     def build_agent_environment(self) -> dict[str,str]:
         opts = self.options
 
@@ -166,19 +197,7 @@ class Config:
         }
         exporter = opts.get("exporter")
         if exporter is not None:
-            _set_otlp_exporter_agent_env(updates, None, exporter)
-
-            traces = exporter.get("traces")
-            if traces is not None:
-                _set_otlp_exporter_agent_env(updates, "TRACES", traces)
-
-            metrics = exporter.get("metrics")
-            if metrics is not None:
-                _set_otlp_exporter_agent_env(updates, "METRICS", metrics)
-
-            logs = exporter.get("logs")
-            if logs is not None:
-                _set_otlp_exporter_agent_env(updates, "LOGS", metrics)
+            _set_exporter_agent_env(updates, exporter)
 
         for key, value in updates.items():
             if value is not None:
@@ -201,10 +220,16 @@ class Config:
 
         exporter = self.options.get("exporter")
         if exporter is not None:
-            protocol = exporter.get("protocol")
-            if protocol is not None and protocol not in {'grpc', 'http'}:
-                _errlog("exporter protocol must be 'grpc' or 'http'")
-                return False
+            if exporter.get("_type") == "datadog":
+                api_key = exporter.get("api_key")
+                if not api_key:
+                    _errlog("Datadog exporter api_key must be set")
+                    return False
+            else:
+                protocol = exporter.get("protocol")
+                if protocol is not None and protocol not in {'grpc', 'http'}:
+                    _errlog("OTLP exporter protocol must be 'grpc' or 'http'")
+                    return False
 
         log_format = self.options.get("log_format")
         if log_format is not None and log_format not in {'json', 'text'}:
@@ -212,6 +237,39 @@ class Config:
             return False
 
         return True
+
+def _set_exporter_agent_env(updates: dict, exporter: OTLPExporter | DatadogExporter) -> None:
+    exp_type = cast(dict, exporter).get("_type")
+    if exp_type == "datadog":
+        _set_datadog_exporter_agent_env(updates, exporter)
+        return
+
+    #
+    # If not Datadog, assume OTLP exporter
+    #
+    _set_otlp_exporter_agent_env(updates, None, exporter)
+
+    traces = exporter.get("traces")
+    if traces is not None:
+        _set_otlp_exporter_agent_env(updates, "TRACES", traces)
+
+    metrics = exporter.get("metrics")
+    if metrics is not None:
+        _set_otlp_exporter_agent_env(updates, "METRICS", metrics)
+
+    logs = exporter.get("logs")
+    if logs is not None:
+        _set_otlp_exporter_agent_env(updates, "LOGS", metrics)
+
+def _set_datadog_exporter_agent_env(updates: dict, exporter: DatadogExporter) -> None:
+    pfx = "DATADOG_EXPORTER_"
+
+    updates.update({
+        "EXPORTER": "datadog", # We must opt in to Datadog
+        pfx + "REGION": exporter.get("region"),
+        pfx + "CUSTOM_ENDPOINT": exporter.get("custom_endpoint"),
+        pfx + "API_KEY": exporter.get("api_key"),
+    })
 
 def _set_otlp_exporter_agent_env(updates: dict, endpoint_type: str | None, exporter: OTLPExporter | OTLPExporterEndpoint | None) -> None:
     pfx = "OTLP_EXPORTER_"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,7 +34,7 @@ def test_client_connect_http(mock_server):
 
     client = Client(
         enabled = True,
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             endpoint = f"http://{addr[0]}:{addr[1]}",
             protocol = "http"
         )
@@ -60,7 +60,7 @@ def test_client_connect_grpc(mock_server):
 
     client = Client(
         enabled = True,
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             endpoint = f"http://{addr[0]}:{addr[1]}",
             protocol = "http"
         )
@@ -83,7 +83,7 @@ def test_client_custom_headers(mock_server):
 
     client = Client(
         enabled = True,
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             endpoint = f"http://{addr[0]}:{addr[1]}",
             protocol = "http",
             headers = {
@@ -112,6 +112,35 @@ def test_client_custom_headers(mock_server):
     assert req.headers.get("Authorization") == "Bearer 12345"
     assert req.headers.get("X-Dataset") == "foobar"
 
+def test_client_datadog(mock_server):
+    addr = mock_server.address()
+
+    client = Client(
+        enabled = True,
+        exporter = Config.datadog_exporter(
+            custom_endpoint= f"http://{addr[0]}:{addr[1]}",
+            api_key = "987654",
+        )
+    )
+    client.start()
+
+    os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"
+    os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http"
+
+    provider = new_http_provider()
+    tracer = new_tracer(provider, "pyrotel.test")
+
+    with tracer.start_as_current_span("test_client_active"):
+        pass
+    provider.shutdown()
+
+    wait_until(2, 0.1, lambda: MockServer.tracker.get_count() > 0)
+
+    assert MockServer.tracker.get_count() == 1
+
+    req = MockServer.tracker.get_requests()[0]
+    assert req.headers.get("DD-API-KEY") == "987654"
+
 def test_client_env_config(mock_server):
     addr = mock_server.address()
 
@@ -139,7 +168,7 @@ def test_client_double_start(mock_server):
 
     opts = Options(
         enabled = True,
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             endpoint = f"http://{addr[0]}:{addr[1]}",
             protocol = "http"
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,7 +19,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
 from src.rotel.agent import agent
 from src.rotel.client import Client
-from src.rotel.config import Config, Options, OTLPExporter
+from src.rotel.config import Config, Options
 from tests.utils import wait_until
 from tests.utils_server import MockServer
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,7 +47,7 @@ def test_config_from_options():
     cl = Rotel(
         enabled = True,
         otlp_grpc_endpoint = "localhost:5317",
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             endpoint = "http://foo2.example.com:4317",
             compression = "gzip",
             headers = {"api-key": "super-secret", "team":"dev"}
@@ -74,7 +74,7 @@ def test_config_env_override():
 
     cl = Rotel(
         enabled = True,
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             endpoint = "http://foo2.example.com:4318",
         )
     )
@@ -93,7 +93,7 @@ def test_config_env_override():
 def test_config_custom_endpoints():
     cl = Rotel(
         enabled = True,
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             traces = OTLPExporterEndpoint(
                 endpoint = "http://foo2.example.com:4318/api/v1/traces",
                 compression = "none",
@@ -111,6 +111,30 @@ def test_config_custom_endpoints():
     assert agent["ROTEL_OTLP_EXPORTER_TRACES_COMPRESSION"] == "none"
     assert agent["ROTEL_OTLP_EXPORTER_METRICS_ENDPOINT"] == "http://foo2.example.com:4318/api/v1/metrics"
 
+def test_datadog_exporter():
+    cl = Rotel(
+        enabled = True,
+        exporter = Config.datadog_exporter(
+            region = "us3",
+            api_key = "2345",
+        )
+    )
+
+    assert cl.config.is_active()
+
+    agent = cl.config.build_agent_environment()
+    assert agent["ROTEL_EXPORTER"] == "datadog"
+    assert agent["ROTEL_DATADOG_EXPORTER_REGION"] == "us3"
+    assert agent["ROTEL_DATADOG_EXPORTER_API_KEY"] == "2345"
+
+    cl = Rotel(
+        enabled = True,
+        exporter = Config.datadog_exporter(
+            region = "us3",
+        )
+    )
+    assert not cl.config.is_active()
+
 def test_config_custom_endpoints_from_env():
     os.environ["ROTEL_OTLP_EXPORTER_TRACES_ENDPOINT"] = "http://foo2.example.com:4318/api/v1/traces"
     os.environ["ROTEL_OTLP_EXPORTER_METRICS_ENDPOINT"] = "http://foo2.example.com:4318/api/v1/metrics"
@@ -118,7 +142,7 @@ def test_config_custom_endpoints_from_env():
 
     cl = Rotel(
         enabled = True,
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             endpoint = "http://foo2.example.com:4318",
         ),
     )
@@ -131,7 +155,7 @@ def test_config_custom_endpoints_from_env():
 def test_config_custom_headers():
     cl = Rotel(
         enabled = True,
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             endpoint = "http://foo2.example.com:4318",
             headers = {
                 "Authorization": "Bearer 1234",
@@ -148,7 +172,7 @@ def test_config_custom_headers():
     os.environ["ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS"] = "Authorization=Bearer 9876,X-Dataset=blah=foo,X-Team=dev"
     cl = Rotel(
         enabled = True,
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             endpoint = "http://foo2.example.com:4318",
         ),
     )
@@ -173,7 +197,7 @@ def test_config_validation():
 
     cfg = Config(Options(
         enabled = True,
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             endpoint = "http://foo.example.com:4317",
             protocol = "grpc",
             batch_max_size = 4096,
@@ -184,7 +208,7 @@ def test_config_validation():
     # invalid protocol
     cfg = Config(Options(
         enabled = True,
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             endpoint = "http://foo.example.com:4317",
             protocol = "unknown"
         )
@@ -195,7 +219,7 @@ def test_config_validation():
     cfg = Config(Options(
         enabled = True,
         log_format = "csv",
-        exporter = OTLPExporter(
+        exporter = Config.otlp_exporter(
             endpoint = "http://foo.example.com:4317",
         )
     ))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 
 from rotel.client import Client as Rotel
-from src.rotel.config import Config, Options, OTLPExporter, OTLPExporterEndpoint
+from src.rotel.config import Config, Options, OTLPExporterEndpoint
 
 
 def test_defaults():

--- a/tests/utils_server.py
+++ b/tests/utils_server.py
@@ -47,6 +47,10 @@ class MockServer(BaseHTTPRequestHandler):
             req = Request(self.path, self.headers)
             self.tracker.add(req)
             self.send_response(200)
+        elif self.path == '/api/v0.2/traces': # datadog
+            req = Request(self.path, self.headers)
+            self.tracker.add(req)
+            self.send_response(200)
         else:
             self.send_response(404)
         self.end_headers()


### PR DESCRIPTION
This brings in support for the experimental Datadog trace exporter. There does not appear to be a good way to set default fields in a TypedDict class, so this introduces helper methods to construct the exporter configs. The helper methods set a type field that allows us to differentiate the exporter types. It still defaults to OTLP if the field is not set.

I was able to test our fake weather API with this update and got the following DD trace waterfall:
![Selection_025](https://github.com/user-attachments/assets/cf200d5d-384a-40b8-af10-f869f2c5d4ea)

Completes: STR-3216