### PR TITLE
Correct Linux wheel build artifacts

### DIFF
--- a/scripts/platform.py
+++ b/scripts/platform.py
@@ -6,8 +6,8 @@ PLATFORM_TAGS = {
 
     # Glibc Linux builds
     # https://peps.python.org/pep-0600/#legacy-manylinux-tags
-    "x86_64-linux": "manylinux2014_x86_64.manylinux_2_17_x86_64",
-    "aarch64-linux": "manylinux2014_aarch64.manylinux_2_17_aarch64",
+    "x86_64-linux": "manylinux_2_34_x86_64",
+    "aarch64-linux": "manylinux_2_34_aarch64",
 
     # "any": "any",
 }


### PR DESCRIPTION
Drop linux2014 tag and update GLIBC version. We may need to update the macos one too, but leaving as a todo.

Completes: STR-3288