### PR TITLE
Multiple exporters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ Source = "https://github.com/streamfold/pyrotel"
 
 [tool.rotel]
 # bump this to upgrade the rotel version
-version = "v0.0.1-alpha16"
+version = "v0.0.1-alpha20"
 
 [tool.hatch.version]
 path = "src/rotel/__about__.py"

--- a/src/rotel/config.py
+++ b/src/rotel/config.py
@@ -126,6 +126,13 @@ class Config:
         """Construct an OTLP exporter config"""
         options["_type"] = "otlp"
         return options
+    
+    @staticmethod
+    def blackhole_exporter() -> BlackholeExporter:
+        """Construct a Blackhole exporter config"""
+        options = BlackholeExporter()
+        options["_type"] = "blackhole"
+        return options
 
     @staticmethod
     def _load_options_from_env() -> Options:

--- a/src/rotel/config.py
+++ b/src/rotel/config.py
@@ -185,6 +185,10 @@ class Config:
 
                 if exporter is not None:
                     env["exporters"][name] = exporter
+            
+            env["exporters_traces"] = as_list(rotel_env("EXPORTERS_TRACES"))
+            env["exporters_metrics"] = as_list(rotel_env("EXPORTERS_METRICS"))
+            env["exporters_logs"] = as_list(rotel_env("EXPORTERS_LOGS"))
 
         else:
             value = as_lower(rotel_env("EXPORTER"))
@@ -276,15 +280,19 @@ class Config:
 
         exporters = opts.get("exporters")
         if exporters is not None:
-            exporters_str = ""
-            for name, exporter in exporters:
-                exporters_str += f"{name}:{cast(dict, exporter).get("_type")}"
+            exporters_list = []
+            for name, exporter in exporters.items():
+                exporter_type = cast(dict, exporter).get("_type")
+                if name == exporter_type:
+                    exporters_list.append(f"{name}")
+                else:
+                    exporters_list.append(f"{name}:{exporter_type}")
 
                 pfx = f"EXPORTER_{name.upper()}_"
                 _set_exporter_agent_env(updates, pfx, exporter)
 
             updates.update({
-                "EXPORTERS": exporters_str,
+                "EXPORTERS": ",".join(exporters_list),
             })
 
             if opts.get("exporters_metrics") is not None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -147,18 +147,18 @@ def test_client_multiple_exporters(mock_server):
     client = Client(
         enabled = True,
         exporters = {
-            'datadog': Config.datadog_exporter(
+            'tracing': Config.datadog_exporter(
                 custom_endpoint= f"http://{addr[0]}:{addr[1]}",
                 api_key = "987a654",
             ),
-            'otlp': Config.otlp_exporter(
+            'metrics': Config.otlp_exporter(
                 endpoint = "http://localhost:4318",
                 protocol = "http",
             ),
             'blackhole': Config.blackhole_exporter(),
         },
-        exporters_traces = ['datadog'],
-        exporters_metrics = ['otlp'],
+        exporters_traces = ['tracing'],
+        exporters_metrics = ['metrics'],
         exporters_logs = ['blackhole'],
     )
     client.start()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -141,6 +141,45 @@ def test_client_datadog(mock_server):
     req = MockServer.tracker.get_requests()[0]
     assert req.headers.get("DD-API-KEY") == "987654"
 
+def test_client_multiple_exporters(mock_server):
+    addr = mock_server.address()
+
+    client = Client(
+        enabled = True,
+        exporters = {
+            'datadog': Config.datadog_exporter(
+                custom_endpoint= f"http://{addr[0]}:{addr[1]}",
+                api_key = "987a654",
+            ),
+            'otlp': Config.otlp_exporter(
+                endpoint = "http://localhost:4318",
+                protocol = "http",
+            ),
+            'blackhole': Config.blackhole_exporter(),
+        },
+        exporters_traces = ['datadog'],
+        exporters_metrics = ['otlp'],
+        exporters_logs = ['blackhole'],
+    )
+    client.start()
+
+    os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:4318"
+    os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http"
+
+    provider = new_http_provider()
+    tracer = new_tracer(provider, "pyrotel.test")
+
+    with tracer.start_as_current_span("test_client_active"):
+        pass
+    provider.shutdown()
+
+    wait_until(2, 0.1, lambda: MockServer.tracker.get_count() > 0)
+
+    assert MockServer.tracker.get_count() == 1
+
+    req = MockServer.tracker.get_requests()[0]
+    assert req.headers.get("DD-API-KEY") == "987a654"
+
 def test_client_clickhouse(mock_server):
     addr = mock_server.address()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -193,6 +193,57 @@ def test_config_multiple_exporters_from_env():
     assert agent["ROTEL_EXPORTERS_METRICS"] == "blackhole"
     assert agent["ROTEL_EXPORTERS_LOGS"] == "logging"
 
+def test_config_invalid_multiple_exporters():
+    cl = Rotel(
+        enabled = True,
+        exporters = {
+            'logging': Config.clickhouse_exporter(
+                endpoint = "http://foo2.example.com:4318",
+            ),
+            'tracing': Config.datadog_exporter(
+                api_key = "12340987",
+            ),
+            'blackhole': Config.blackhole_exporter(),
+        },
+    )
+    
+    # no exporter lists
+    assert not cl.config.is_active()
+
+    cl = Rotel(
+        enabled = True,
+        exporters = {
+            'logging': Config.clickhouse_exporter(
+                endpoint = "http://foo2.example.com:4318",
+            ),
+            'tracing': Config.datadog_exporter(
+                api_key = "12340987",
+            ),
+            'blackhole': Config.blackhole_exporter(),
+        },
+        exporters_traces = ['tracing'],
+    )
+
+    # should be fixed
+    assert cl.config.is_active()
+
+    cl = Rotel(
+        enabled = True,
+        exporters = {
+            'logging': Config.clickhouse_exporter(
+                endpoint = "http://foo2.example.com:4318",
+            ),
+            'tracing': Config.datadog_exporter(
+                api_key = "12340987",
+            ),
+            'blackhole': Config.blackhole_exporter(),
+        },
+        exporters_traces = ['not_exist'],
+    )
+
+    # exporter does not exist
+    assert not cl.config.is_active()
+
 def test_config_invalid_int_no_error():
     os.environ["ROTEL_BATCH_MAX_SIZE"] = "abc" # should not error
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -165,6 +165,34 @@ def test_clickhouse_exporter():
     )
     assert not cl.config.is_active()
 
+def test_config_multiple_exporters_from_env():
+    os.environ["ROTEL_EXPORTERS"] = "logging:clickhouse,tracing:datadog,blackhole"
+    os.environ["ROTEL_EXPORTER_LOGGING_ENDPOINT"] = "https://endpoint1.com"
+    os.environ["ROTEL_EXPORTER_TRACING_API_KEY"] = "12340987"
+    os.environ["ROTEL_EXPORTERS_TRACES"] = "tracing"
+    os.environ["ROTEL_EXPORTERS_METRICS"] = "blackhole"
+    os.environ["ROTEL_EXPORTERS_LOGS"] = "logging"
+
+    cl = Rotel(
+        enabled = True,
+    )
+
+    assert cl.config.is_active()
+    assert cl.config.options["exporters"]["logging"]["endpoint"] == "https://endpoint1.com"
+    assert cl.config.options["exporters"]["tracing"]["api_key"] == "12340987"
+    assert cl.config.options["exporters"]["blackhole"] is not None
+    assert cl.config.options["exporters_traces"] == ["tracing"]
+    assert cl.config.options["exporters_metrics"] == ["blackhole"]
+    assert cl.config.options["exporters_logs"] == ["logging"]
+
+    agent = cl.config.build_agent_environment()
+    assert agent["ROTEL_EXPORTERS"] == "logging:clickhouse,tracing:datadog,blackhole"
+    assert agent["ROTEL_EXPORTER_LOGGING_ENDPOINT"] == "https://endpoint1.com"
+    assert agent["ROTEL_EXPORTER_TRACING_API_KEY"] == "12340987"
+    assert agent["ROTEL_EXPORTERS_TRACES"] == "tracing"
+    assert agent["ROTEL_EXPORTERS_METRICS"] == "blackhole"
+    assert agent["ROTEL_EXPORTERS_LOGS"] == "logging"
+
 def test_config_invalid_int_no_error():
     os.environ["ROTEL_BATCH_MAX_SIZE"] = "abc" # should not error
 


### PR DESCRIPTION
Add support for multiple exporters and make them the default configuration. We maintain backwards compatibility for the existing exporter configuration, but I think we should deprecate that in the future given the complexity in supporting both formats.

Completes: STR-3493