### PR TITLE
Add kafka exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,42 +89,41 @@ To set the endpoint the OpenTelemetry SDK will use, set the following environmen
 
 ## Configuration
 
-This is the full list of options and their environment variable alternatives. Any defaults left blank in the table are either False or None.
+This is the full list of global options and their environment variable alternatives. Any defaults left blank in the table are either False or None.
 
-| Option Name                    | Type                                                  | Environ                              | Default              | Options               |
-|--------------------------------|-------------------------------------------------------|--------------------------------------|----------------------|-----------------------|
-| enabled                        | bool                                                  | ROTEL_ENABLED                        |                      |                       |
-| pid_file                       | str                                                   | ROTEL_PID_FILE                       | /tmp/rotel-agent.pid |                       |
-| log_file                       | str                                                   | ROTEL_LOG_FILE                       | /tmp/rotel-agent.log |                       |
-| log_format                     | str                                                   | ROTEL_LOG_FORMAT                     | text                 | json, text            |
-| debug_log                      | list[str]                                             | ROTEL_DEBUG_LOG                      |                      | traces, metrics, logs |
-| otlp_grpc_endpoint             | str                                                   | ROTEL_OTLP_GRPC_ENDPOINT             | localhost:4317       |                       |
-| otlp_http_endpoint             | str                                                   | ROTEL_OTLP_HTTP_ENDPOINT             | localhost:4318       |                       |
-| otlp_receiver_traces_disabled  | bool                                                  | ROTEL_OTLP_RECEIVER_TRACES_DISABLED  |                      |                       |
-| otlp_receiver_metrics_disabled | bool                                                  | ROTEL_OTLP_RECEIVER_METRICS_DISABLED |                      |                       |
-| otlp_receiver_logs_disabled    | bool                                                  | ROTEL_OTLP_RECEIVER_LOGS_DISABLED    |                      |                       |
-| exporter                       | OTLPExporter \| DatadogExporter \| ClickhouseExporter |                                      |                      |                       |
+| Option Name        | Type      | Environ              | Default              | Options               |
+|--------------------|-----------|----------------------|----------------------|-----------------------|
+| enabled            | bool      | ROTEL_ENABLED        |                      |                       |
+| pid_file           | str       | ROTEL_PID_FILE       | /tmp/rotel-agent.pid |                       |
+| log_file           | str       | ROTEL_LOG_FILE       | /tmp/rotel-agent.log |                       |
+| log_format         | str       | ROTEL_LOG_FORMAT     | text                 | json, text            |
+| debug_log          | list[str] | ROTEL_DEBUG_LOG      |                      | traces, metrics, logs |
+| otlp_grpc_endpoint | str       | ROTEL_OTLP_GRPC_ENDPOINT | localhost:4317   |                       |
+| otlp_http_endpoint | str       | ROTEL_OTLP_HTTP_ENDPOINT | localhost:4318   |                       |
+
+For each exporter you would like to use, see the configuration options below. Exporters should be
+assigned to the `exporters` dict with a custom name.
 
 ### OTLP Exporter
 
 To construct an OTLP exporter, use the method `Config.otlp_exporter()` with the following options.
 
-| Option Name            | Type           | Environ                                    | Default | Options      |
-|------------------------|----------------|--------------------------------------------|---------|--------------|
-| endpoint               | str            | ROTEL_OTLP_EXPORTER_ENDPOINT               |         |              |
-| protocol               | str            | ROTEL_OTLP_EXPORTER_PROTOCOL               | grpc    | grpc or http |
-| headers                | dict[str, str] | ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS         |         |              |
-| compression            | str            | ROTEL_OTLP_EXPORTER_COMPRESSION            | gzip    | gzip or none |
-| request_timeout        | str            | ROTEL_OTLP_EXPORTER_REQUEST_TIMEOUT        | 5s      |              |
-| retry_initial_backoff  | str            | ROTEL_OTLP_EXPORTER_RETRY_INITIAL_BACKOFF  | 5s      |              |
-| retry_max_backoff      | str            | ROTEL_OTLP_EXPORTER_RETRY_MAX_BACKOFF      | 30s     |              |
-| retry_max_elapsed_time | str            | ROTEL_OTLP_EXPORTER_RETRY_MAX_ELAPSED_TIME | 300s    |              |
-| batch_max_size         | int            | ROTEL_OTLP_EXPORTER_BATCH_MAX_SIZE         | 8192    |              |
-| batch_timeout          | str            | ROTEL_OTLP_EXPORTER_BATCH_TIMEOUT          | 200ms   |              |
-| tls_cert_file          | str            | ROTEL_OTLP_EXPORTER_TLS_CERT_FILE          |         |              |
-| tls_key_file           | str            | ROTEL_OTLP_EXPORTER_TLS_KEY_FILE           |         |              |
-| tls_ca_file            | str            | ROTEL_OTLP_EXPORTER_TLS_CA_FILE            |         |              |
-| tls_skip_verify        | bool           | ROTEL_OTLP_EXPORTER_TLS_SKIP_VERIFY        |         |              |
+| Option Name            | Type           | Default | Options      |
+|------------------------|----------------|---------|--------------|
+| endpoint               | str            |         |              |
+| protocol               | str            | grpc    | grpc or http |
+| headers                | dict[str, str] |         |              |
+| compression            | str            | gzip    | gzip or none |
+| request_timeout        | str            | 5s      |              |
+| retry_initial_backoff  | str            | 5s      |              |
+| retry_max_backoff      | str            | 30s     |              |
+| retry_max_elapsed_time | str            | 300s    |              |
+| batch_max_size         | int            | 8192    |              |
+| batch_timeout          | str            | 200ms   |              |
+| tls_cert_file          | str            |         |              |
+| tls_key_file           | str            |         |              |
+| tls_ca_file            | str            |         |              |
+| tls_skip_verify        | bool           |         |              |
 
 ### Datadog Exporter
 
@@ -132,32 +131,58 @@ Rotel provides an experimental [Datadog exporter](https://github.com/streamfold/
 that supports traces at the moment. To use it instead of the OTLP exporter,
 use the method `Config.datadog_exporter()` with the following options.
 
-| Option Name     | Type | Environ                                | Default | Options                |
-|-----------------|------|----------------------------------------|---------|------------------------|
-| region          | str  | ROTEL_DATADOG_EXPORTER_REGION          | us1     | us1, us3, us5, eu, ap1 |
-| custom_endpoint | str  | ROTEL_DATADOG_EXPORTER_CUSTOM_ENDPOINT |         |                        |
-| api_key         | str  | ROTEL_DATADOG_EXPORTER_API_KEY         |         |                        |
-
-When configuring Rotel with only environment variables, you must set `ROTEL_EXPORTER=datadog` in addition to the above
-environment variables.
+| Option Name     | Type | Default | Options                |
+|-----------------|------|---------|------------------------|
+| region          | str  | us1     | us1, us3, us5, eu, ap1 |
+| custom_endpoint | str  |         |                        |
+| api_key         | str  |         |                        |
 
 ### Clickhouse Exporter
 
-Rotel provides a Clickhouse exporter with support for traces and logs. To use the Clickhouse exporter instead of the OTLP exporter,
+Rotel provides a Clickhouse exporter with support metrics, logs, and traces. To use the Clickhouse exporter instead of the OTLP exporter,
 use the method `Config.clickhouse_exporter()` with the following options.
 
-| Option Name  | Type | Environ                                | Default | Options |
-|--------------|------|----------------------------------------|---------|---------|
-| endpoint     | str  | ROTEL_CLICKHOUSE_EXPORTER_ENDPOINT     |         |         |
-| database     | str  | ROTEL_CLICKHOUSE_EXPORTER_DATABASE     | otel    |         |
-| table_prefix | str  | ROTEL_CLICKHOUSE_EXPORTER_TABLE_PREFIX | otel    |         |
-| compression  | str  | ROTEL_CLICKHOUSE_EXPORTER_COMPRESSION  | lz4     |         |
-| async_insert | bool | ROTEL_CLICKHOUSE_EXPORTER_ASYNC_INSERT | true    |         |
-| user         | str  | ROTEL_CLICKHOUSE_EXPORTER_USER         |         |         |
-| password     | str  | ROTEL_CLICKHOUSE_EXPORTER_PASSWORD     |         |         |
+| Option Name  | Type | Default | Options |
+|--------------|------|---------|---------|
+| endpoint     | str  |         |         |
+| database     | str  | otel    |         |
+| table_prefix | str  | otel    |         |
+| compression  | str  | lz4     |         |
+| async_insert | bool | true    |         |
+| user         | str  |         |         |
+| password     | str  |         |         |
 
-When configuring Rotel with only environment variables, you must set `ROTEL_EXPORTER=clickhouse` in addition to the above
-environment variables.
+### Kafka Exporter
+
+Rotel provides a Kafka exporter with support for metrics, logs, and traces. To use the Kafka exporter instead of the OTLP exporter,
+use the method `Config.kafka_exporter()` with the following options.
+
+| Option Name                                | Type | Default           | Options                                                                      |
+|--------------------------------------------|------|-------------------|------------------------------------------------------------------------------|
+| brokers                                    | list | localhost:9092    |                                                                              |
+| traces_topic                               | str  | otlp_traces       |                                                                              |
+| logs_topic                                 | str  | otlp_logs         |                                                                              |
+| metrics_topic                              | str  | otlp_metrics      |                                                                              |
+| format                                     | str  | protobuf          | json, protobuf                                                               |
+| compression                                | str  | none              | gzip, snappy, lz4, zstd, none                                                |
+| acks                                       | str  | one               | all, one, none                                                               |
+| client_id                                  | str  | rotel             |                                                                              |
+| max_message_bytes                          | int  | 1000000           |                                                                              |
+| linger_ms                                  | int  | 5                 |                                                                              |
+| retries                                    | int  | 2147483647        |                                                                              |
+| retry_backoff_ms                           | int  | 100               |                                                                              |
+| retry_backoff_max_ms                       | int  | 1000              |                                                                              |
+| message_timeout_ms                         | int  | 300000            |                                                                              |
+| request_timeout_ms                         | int  | 30000             |                                                                              |
+| batch_size                                 | int  | 1000000           |                                                                              |
+| partitioner                                | str  | consistent-random | consistent, consistent-randomm, murmur2-random, murmur2, fnv1a, fnv1a-random |
+| partitioner_metrics_by_resource_attributes | str  | 1000              |                                                                              |
+| partitioner_logs_by_resource_attributes    | str  | 1000              |                                                                              |
+| custom_config                              | str  | 1000              |                                                                              |
+| sasl_username                              | str  |                   |                                                                              |
+| sasl_password                              | str  |                   |                                                                              |
+| sasl_mechanism                             | str  |                   |                                                                              |
+| security_protocol                          | str  | PLAINTEXT         | PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL                                     |
 
 ### Multiple exporters
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,10 @@ classifiers = [
     # Application status
     "Development Status :: 3 - Alpha",
 ]
-dependencies = [
-    "typing-extensions"
-]
+dependencies = ["typing-extensions"]
 
 [project.optional-dependencies]
-dev = [
-    "pkginfo>=1.12.0",
-    "pytest>=7.0",
-    "twine>=6.1.0",
-]
+dev = ["pkginfo>=1.12.0", "pytest>=7.0", "twine>=6.1.0"]
 
 [project.urls]
 Homepage = "https://github.com/streamfold/pyrotel"
@@ -42,7 +36,7 @@ Source = "https://github.com/streamfold/pyrotel"
 
 [tool.rotel]
 # bump this to upgrade the rotel version
-version = "v0.0.1-alpha20"
+version = "v0.0.1-alpha22"
 
 [tool.hatch.version]
 path = "src/rotel/__about__.py"
@@ -52,9 +46,7 @@ sources = ["src"]
 exclude = ["scripts", "tests", "conftest.py"]
 
 [tool.hatch.build.targets.wheel]
-artifacts = [
-    "src/rotel/rotel-agent",
-]
+artifacts = ["src/rotel/rotel-agent"]
 
 [tool.hatch.envs.default]
 installer = "uv"
@@ -67,7 +59,7 @@ dependencies = [
     "opentelemetry-sdk",
     "opentelemetry-exporter-otlp-proto-http",
     "opentelemetry-exporter-otlp-proto-grpc",
-    "tomli ; python_version < '3.11'"
+    "tomli ; python_version < '3.11'",
 ]
 
 [tool.hatch.envs.build]
@@ -82,29 +74,18 @@ for = "_ROTEL_AGENT_ARCH=\"{args}\" hatch build -t wheel"
 path = "scripts/build_hook.py"
 
 [tool.pytest.ini_options]
-pythonpath = [
-    "src"
-]
+pythonpath = ["src"]
 
 [[tool.hatch.envs.test.matrix]]
 python = ["310", "311", "312", "313"]
 
 [tool.hatch.envs.lint]
 detached = true
-dependencies = [
-    "isort",
-    "ruff",
-]
+dependencies = ["isort", "ruff"]
 
 [tool.hatch.envs.lint.scripts]
-check = [
-    "isort --check .",
-    "ruff check ."
-]
-fmt = [
-    "isort .",
-    "ruff check --fix ."
-]
+check = ["isort --check .", "ruff check ."]
+fmt = ["isort .", "ruff check --fix ."]
 
 [tool.isort]
 profile = "black"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -165,6 +165,25 @@ def test_clickhouse_exporter():
     )
     assert not cl.config.is_active()
 
+def test_kafka_exporter():
+    cl = Rotel(
+        enabled = True,
+        exporters = {
+            'stream': Config.kafka_exporter(
+                brokers = ["127.0.0.1:9092", "127.0.0.2:9092"],
+                traces_topic = "rotel-traces",
+            )
+        },
+        exporters_traces = ["stream"]
+    )
+
+    assert cl.config.is_active()
+
+    agent = cl.config.build_agent_environment()
+    assert agent["ROTEL_EXPORTERS"] == "stream:kafka"
+    assert agent["ROTEL_EXPORTER_STREAM_BROKERS"] == "127.0.0.1:9092,127.0.0.2:9092"
+    assert agent["ROTEL_EXPORTER_STREAM_TRACES_TOPIC"] == "rotel-traces"
+
 def test_config_multiple_exporters_from_env():
     os.environ["ROTEL_EXPORTERS"] = "logging:clickhouse,tracing:datadog,blackhole"
     os.environ["ROTEL_EXPORTER_LOGGING_ENDPOINT"] = "https://endpoint1.com"


### PR DESCRIPTION
Brings in the Kafka exporter support with typed configuration. The Kafka exporter pushes our limits on config options, while this follows the existing patterns we may find that we need to improve the configuration handling in the future.

Completes: STR-3507