### PR TITLE
Enable CH options + fix bools

### DIFF
--- a/src/rotel/config.py
+++ b/src/rotel/config.py
@@ -63,6 +63,8 @@ class ClickhouseExporter(TypedDict, total=False):
     async_insert: bool | None
     user: str | None
     password: str | None
+    enable_json: bool | None
+    json_underscore: bool | None
 
 class BlackholeExporter(TypedDict, total=False):
     _type: str | None # set with builder method
@@ -184,6 +186,8 @@ class Config:
                             async_insert = as_bool(rotel_env(pfx + "ASYNC_INSERT")),
                             user = rotel_env(pfx + "USER"),
                             password = rotel_env(pfx + "PASSWORD"),
+                            enable_json = as_bool(rotel_env(pfx + "ENABLE_JSON")),
+                            json_underscore = as_bool(rotel_env(pfx + "JSON_UNDERSCORE")),
                         )
                     case "blackhole":
                         exporter = BlackholeExporter(
@@ -235,6 +239,8 @@ class Config:
                     async_insert = as_bool(rotel_env(pfx + "ASYNC_INSERT")),
                     user = rotel_env(pfx + "USER"),
                     password = rotel_env(pfx + "PASSWORD"),
+                    enable_json = as_bool(rotel_env(pfx + "ENABLE_JSON")),
+                    json_underscore = as_bool(rotel_env(pfx + "JSON_UNDERSCORE")),
                 )
                 env["exporter"] = exporter
 
@@ -324,6 +330,8 @@ class Config:
             if value is not None:
                 if isinstance(value, list):
                     value = ",".join(value)
+                if isinstance(value, bool):
+                    value = str(value).lower()
                 if isinstance(value, dict):
                     hdr_list = []
                     for k, v in value.items():
@@ -447,6 +455,8 @@ def _set_clickhouse_exporter_agent_env(updates: dict, pfx: str | None, exporter:
         pfx + "ASYNC_INSERT": exporter.get("async_insert"),
         pfx + "USER": exporter.get("user"),
         pfx + "PASSWORD": exporter.get("password"),
+        pfx + "ENABLE_JSON": exporter.get("enable_json"),
+        pfx + "JSON_UNDERSCORE": exporter.get("json_underscore"),
     })
 
 def _set_otlp_exporter_agent_env(updates: dict, pfx: str | None, endpoint_type: str | None, exporter: OTLPExporter | OTLPExporterEndpoint | None) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -188,8 +188,9 @@ def test_client_clickhouse(mock_server):
         exporter = Config.clickhouse_exporter(
             endpoint = f"http://{addr[0]}:{addr[1]}",
             user = "foobar",
-            password = "my-password"
-        )
+            password = "my-password",
+            enable_json = True,
+        ),
     )
     client.start()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,7 +41,7 @@ def test_config_env_basic():
     assert agent.get("ROTEL_OTLP_EXPORTER") is None
     assert agent["ROTEL_OTLP_EXPORTER_ENDPOINT"] == "http://foo.example.com:4317"
     assert agent["ROTEL_OTLP_EXPORTER_CUSTOM_HEADERS"] == "api=1234,team=8793"
-    assert agent["ROTEL_OTLP_EXPORTER_TLS_SKIP_VERIFY"] == "True"
+    assert agent["ROTEL_OTLP_EXPORTER_TLS_SKIP_VERIFY"] == "true"
 
 def test_config_from_options():
     cl = Rotel(


### PR DESCRIPTION
Adds enable_json and json_underscore options to the Clickhouse exporter. This also caught a bug that bools must be lower cased, so address that.

Completes: STR-3510